### PR TITLE
Rely on scrollIntoView() when doing feature detection

### DIFF
--- a/src/jquery.rtl-scroll.js
+++ b/src/jquery.rtl-scroll.js
@@ -2,14 +2,14 @@
 /*global jQuery */
 (function ($) {
     'use strict';
-    var definer = $('<div dir="rtl" style="font-size: 14px; width: 4px; height: 1px; position: absolute; top: -1000px; overflow: scroll">ABCD</div>').appendTo('body')[0],
+    var definer = $('<div dir="rtl" style="width: 1px; height: 1px; position: absolute; top: -1000px; overflow: hidden"><div style="width: 2px"><div style="display: inline-block; width: 1px"></div><div style="display: inline-block; width: 1px"></div></div></div>').appendTo('body')[0],
         type = 'reverse';
 
     if (definer.scrollLeft > 0) {
         type = 'default';
     } else {
-        definer.scrollLeft = 1;
-        if (definer.scrollLeft === 0) {
+        definer.children[0].children[1].scrollIntoView();
+        if (definer.scrollLeft < 0) {
             type = 'negative';
         }
     }


### PR DESCRIPTION
The Chromium community is moving to standard behavior from the CSSOM
specification [1]. In order to launch the feature and analyze potential
broken URLs, they are counting pages setting the scrollLeft of a RTL
scroller to a positive value. Websites using the current version of
jquery.rtl-scroll will trigger the counter [2]. In order to workaround
that issue, rely on Element.scrollIntoView() instead.

This patch also replaces text with divs and removes scrollbar from
the scroller, in order to make measurements more reliable.

[1] https://www.chromestatus.com/feature/5759578031521792
[2] https://github.com/othree/jquery.rtl-scroll-type/issues/6