### PR TITLE
Use a 'position: fixed' scroller.

### DIFF
--- a/src/jquery.rtl-scroll.js
+++ b/src/jquery.rtl-scroll.js
@@ -2,7 +2,7 @@
 /*global jQuery */
 (function ($) {
     'use strict';
-    var definer = $('<div dir="rtl" style="width: 1px; height: 1px; position: absolute; top: -1000px; overflow: hidden"><div style="width: 2px"><div style="display: inline-block; width: 1px"></div><div style="display: inline-block; width: 1px"></div></div></div>').appendTo('body')[0],
+    var definer = $('<div dir="rtl" style="width: 1px; height: 1px; position: fixed; top: 0px; left: 0px; overflow: hidden"><div style="width: 2px"><div style="display: inline-block; width: 1px"></div><div style="display: inline-block; width: 1px"></div></div></div>').appendTo('body')[0],
         type = 'reverse';
 
     if (definer.scrollLeft > 0) {


### PR DESCRIPTION
scrollIntoView() might scroll the page, so make things safer by
wrapping into a 'position: fixed' scroller.

https://github.com/othree/jquery.rtl-scroll-type/issues/6